### PR TITLE
feat: connector list filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Bitcoin Connect exposes the following web components for allowing users to conne
 
 ##### Common Attributes (can be passed to any Bitcoin Connect component)
 
-- `app-name` (React: `appName`) - Name of the app requesting access to wallet. Currently used for NWC connections
+- `app-name` (React: `appName`) - Name of the app requesting access to wallet. Currently used for NWC connections (Alby and Mutiny)
+- `filters` - Filter the type of connectors you want to show. Example: "nwc" (only show NWC connectors). Multiple filters can be separated by a comma e.g. `nwc,second_filter`.
 
 #### Window Events
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Bitcoin Connect exposes the following web components for allowing users to conne
 ##### Common Attributes (can be passed to any Bitcoin Connect component)
 
 - `app-name` (React: `appName`) - Name of the app requesting access to wallet. Currently used for NWC connections (Alby and Mutiny)
-- `filters` - Filter the type of connectors you want to show. Example: "nwc" (only show NWC connectors). Multiple filters can be separated by a comma e.g. `nwc,second_filter`.
+- `filters` - **EXPERIMENTAL:** Filter the type of connectors you want to show. Example: "nwc" (only show NWC connectors). Multiple filters can be separated by a comma e.g. `nwc,second_filter`.
 
 #### Window Events
 

--- a/dev/vite/index.html
+++ b/dev/vite/index.html
@@ -121,9 +121,22 @@
       Force Light
     </button>
 
+    <h1>Settings</h1>
+    <p>Name (e.g. Zap.Stream)</p>
+    <input
+      id="app-name"
+      onchange="localStorage.setItem('app-name', document.getElementById('app-name').value); window.location.reload()"
+    />
+    <p>Filters (e.g. nwc)</p>
+    <input
+      id="filters"
+      onchange="localStorage.setItem('filters', document.getElementById('filters').value); window.location.reload()"
+    />
+    <br />
+    <br />
     <h1>Components</h1>
     <h2>Button</h2>
-    <bc-button app-name="Bitcoin Connect Vite"></bc-button>
+    <bc-button id="first-button"></bc-button>
     <br /><br />
     <div class="theme-geyser">
       <bc-button></bc-button>
@@ -177,5 +190,14 @@
 
     <h2>Pay an invoice</h2>
     <button onclick="payInvoice()">Pay</button>
+    <script>
+      const appName = localStorage.getItem('app-name');
+      document.getElementById('app-name').value = appName;
+      document.getElementById('first-button').setAttribute('app-name', appName);
+
+      const filters = localStorage.getItem('filters');
+      document.getElementById('filters').value = filters;
+      document.getElementById('first-button').setAttribute('filters', filters);
+    </script>
   </body>
 </html>

--- a/react/src/components/Button.tsx
+++ b/react/src/components/Button.tsx
@@ -10,5 +10,5 @@ export const Button: React.FC<ButtonProps> = (props) => {
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  return <bc-button app-name={props.appName} />;
+  return <bc-button app-name={props.appName} filters={props.filters} />;
 };

--- a/react/src/components/Modal.tsx
+++ b/react/src/components/Modal.tsx
@@ -10,7 +10,7 @@ export const Modal: React.FC<ModalProps> = (props) => {
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  return <bc-modal app-name={props.appName} />;
+  return <bc-modal app-name={props.appName} filters={props.filters} />;
 };
 
 // TODO: move to bitcoin connect package and just re-export it here

--- a/react/src/types/ComponentProps.ts
+++ b/react/src/types/ComponentProps.ts
@@ -5,4 +5,5 @@ export type ComponentProps = {
   onModalOpened?(): void;
   onModalClosed?(): void;
   appName?: string;
+  filters?: string;
 };

--- a/src/components/BitcoinConnectElement.ts
+++ b/src/components/BitcoinConnectElement.ts
@@ -2,6 +2,7 @@ import {loadFonts} from './utils/loadFonts';
 import {property, state} from 'lit/decorators.js';
 import store from '../state/store';
 import {InternalElement} from './internal/InternalElement';
+import {ConnectorFilter} from '../types/ConnectorFilter';
 
 /**
  * @fires bc:connected - Indicates a wallet has been connected and window.webln is now available and enabled
@@ -24,11 +25,23 @@ export class BitcoinConnectElement extends InternalElement {
   @state()
   protected _appName: string | undefined = undefined;
 
+  @state()
+  protected _filters: ConnectorFilter[] | undefined = undefined;
+
   @property({
     type: String,
     attribute: 'app-name',
   })
   appName?: string;
+
+  @property({
+    type: String,
+    attribute: 'filters',
+    converter(value, _type) {
+      return value?.split(',');
+    },
+  })
+  filters?: ConnectorFilter[];
 
   constructor() {
     super();
@@ -39,6 +52,7 @@ export class BitcoinConnectElement extends InternalElement {
     this._balance = store.getState().balance;
     this._connectorName = store.getState().connectorName;
     this._appName = store.getState().appName;
+    this._filters = store.getState().filters;
 
     // TODO: handle unsubscribe
     store.subscribe((store) => {
@@ -48,6 +62,7 @@ export class BitcoinConnectElement extends InternalElement {
       this._balance = store.balance;
       this._connectorName = store.connectorName;
       this._appName = store.appName;
+      this._filters = store.filters;
     });
   }
 
@@ -55,6 +70,9 @@ export class BitcoinConnectElement extends InternalElement {
     super.connectedCallback();
     if (this.appName != undefined) {
       store.getState().setAppName(this.appName);
+    }
+    if (this.filters != undefined) {
+      store.getState().setFilters(this.filters);
     }
   }
 }

--- a/src/components/BitcoinConnectElement.ts
+++ b/src/components/BitcoinConnectElement.ts
@@ -35,7 +35,7 @@ export class BitcoinConnectElement extends InternalElement {
   appName?: string;
 
   @property({
-    type: String,
+    type: Array,
     attribute: 'filters',
     converter(value, _type) {
       return value?.split(',');

--- a/src/components/bc-connector-list.ts
+++ b/src/components/bc-connector-list.ts
@@ -1,4 +1,4 @@
-import {html} from 'lit';
+import {TemplateResult, html} from 'lit';
 import {withTwind} from './twind/withTwind.js';
 import {BitcoinConnectElement} from './BitcoinConnectElement.js';
 import {customElement} from 'lit/decorators.js';
@@ -10,15 +10,24 @@ import './connectors/index.js';
 @customElement('bc-connector-list')
 export class ConnectorList extends withTwind()(BitcoinConnectElement) {
   override render() {
+    // TODO: find a better way to filter these when multiple filters exist
+    // TODO: allow re-ordering connectors
+    const connectors: TemplateResult<1>[] = [];
+    connectors.push(html`<bc-alby-nwc-connector></bc-alby-nwc-connector>`);
+    connectors.push(html`<bc-mutiny-nwc-connector></bc-mutiny-nwc-connector>`);
+    connectors.push(html`<bc-nwc-connector></bc-nwc-connector>`);
+    if (!this._filters || this._filters.indexOf('nwc') === -1) {
+      if (window.webln) {
+        connectors.push(
+          html`<bc-extension-connector></bc-extension-connector>`
+        );
+      }
+      connectors.push(html`<bc-lnbits-connector></bc-lnbits-connector>`);
+      connectors.push(html`<bc-lnc-connector></bc-lnc-connector>`);
+    }
+
     return html` <div class="flex justify-center items-start flex-wrap gap-4">
-      ${window.webln
-        ? html`<bc-extension-connector></bc-extension-connector>`
-        : null}
-      <bc-alby-nwc-connector></bc-alby-nwc-connector>
-      <bc-mutiny-nwc-connector></bc-mutiny-nwc-connector>
-      <bc-lnc-connector></bc-lnc-connector>
-      <bc-lnbits-connector></bc-lnbits-connector>
-      <bc-nwc-connector></bc-nwc-connector>
+      ${connectors}
     </div>`;
   }
 }

--- a/src/components/bc-start.ts
+++ b/src/components/bc-start.ts
@@ -75,8 +75,13 @@ export class Start extends withTwind()(BitcoinConnectElement) {
               <span>Disconnect</span>
             </bci-button>`
         : html`
-            <h1 class="my-8 ${classes['text-neutral-primary']}">
-              How would you like to connect?
+            <h1
+              class="my-8 ${classes[
+                'text-neutral-primary'
+              ]} w-64 max-w-full text-center"
+            >
+              How would you like to
+              connect${this._appName ? `\nto ${this._appName}` : ''}?
             </h1>
 
             <bc-connector-list></bc-connector-list>

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -4,6 +4,7 @@ import {connectors} from '../connectors';
 import {dispatchEvent} from '../utils/dispatchEvent';
 import {Connector} from '../connectors/Connector';
 import {Route as Route} from '../components/routes';
+import {ConnectorFilter} from '../types/ConnectorFilter';
 
 interface PrivateStore {
   readonly connector: Connector | undefined;
@@ -31,6 +32,7 @@ interface Store {
   readonly balance: number | undefined;
   readonly connectorName: string | undefined;
   readonly appName: string | undefined;
+  readonly filters: ConnectorFilter[] | undefined;
 
   connect(config: ConnectorConfig): void;
   disconnect(): void;
@@ -38,6 +40,7 @@ interface Store {
   setBalance(balance: number | undefined): void;
   setRoute(route: Route): void;
   setAppName(appName: string): void;
+  setFilters(filters: ConnectorFilter[]): void;
 }
 
 const store = createStore<Store>((set, get) => ({
@@ -48,6 +51,7 @@ const store = createStore<Store>((set, get) => ({
   balance: undefined,
   connectorName: undefined,
   appName: undefined,
+  filters: undefined,
   connect: async (config: ConnectorConfig) => {
     dispatchEvent('bc:connecting');
     set({
@@ -113,6 +117,9 @@ const store = createStore<Store>((set, get) => ({
   },
   setAppName: (appName) => {
     set({appName});
+  },
+  setFilters: (filters) => {
+    set({filters});
   },
 }));
 

--- a/src/types/ConnectorFilter.ts
+++ b/src/types/ConnectorFilter.ts
@@ -1,0 +1,1 @@
+export type ConnectorFilter = 'nwc';


### PR DESCRIPTION
Fixes https://github.com/getAlby/bitcoin-connect/issues/11 and https://github.com/getAlby/bitcoin-connect/issues/89

This allows you to provide a `filters="nwc"` argument to the button or modal to only show nwc connectors.

I chose this approach to support future filters (maybe such as realtime payment options for gaming, which might exclude some future mobile wallets)

I think also should be considered how we can allow the user to reorder the connectors (and how to fairly order them by default?)

- [x] Update React wrapper package