### PR TITLE
Feat/error messages

### DIFF
--- a/src/components/BitcoinConnectElement.ts
+++ b/src/components/BitcoinConnectElement.ts
@@ -28,6 +28,9 @@ export class BitcoinConnectElement extends InternalElement {
   @state()
   protected _filters: ConnectorFilter[] | undefined = undefined;
 
+  @state()
+  protected _error: string | undefined = undefined;
+
   @property({
     type: String,
     attribute: 'app-name',
@@ -53,6 +56,7 @@ export class BitcoinConnectElement extends InternalElement {
     this._connectorName = store.getState().connectorName;
     this._appName = store.getState().appName;
     this._filters = store.getState().filters;
+    this._error = store.getState().error;
 
     // TODO: handle unsubscribe
     store.subscribe((store) => {
@@ -63,6 +67,7 @@ export class BitcoinConnectElement extends InternalElement {
       this._connectorName = store.connectorName;
       this._appName = store.appName;
       this._filters = store.filters;
+      this._error = store.error;
     });
   }
 

--- a/src/components/bc-button.ts
+++ b/src/components/bc-button.ts
@@ -72,7 +72,7 @@ export class Button extends withTwind()(BitcoinConnectElement) {
                 'text-brand-mixed'
               ]}"
               ><span class="font-mono"
-                >${(this._balance || 0).toLocaleString('en', {
+                >${(this._balance || 0).toLocaleString(undefined, {
                   useGrouping: true,
                 })}
                 sats</span

--- a/src/components/bc-modal.ts
+++ b/src/components/bc-modal.ts
@@ -2,6 +2,7 @@ import {html} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {BitcoinConnectElement} from './BitcoinConnectElement';
 import './bc-router-outlet.js';
+import './internal/bci-connecting';
 import store from '../state/store';
 import {dispatchEvent} from '../utils/dispatchEvent';
 import {withTwind} from './twind/withTwind';
@@ -85,7 +86,11 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
           class="flex w-full"
           .onClose=${this._handleClose}
         ></bc-modal-header>
-        <bc-router-outlet class="flex w-full"></bc-router-outlet>
+        <div class="flex w-full pt-8">
+          ${this._connecting
+            ? html`<bci-connecting class="flex w-full"></bci-connecting>`
+            : html` <bc-router-outlet class="flex w-full"></bc-router-outlet>`}
+        </div>
       </div>
     </div>`;
   }

--- a/src/components/bc-modal.ts
+++ b/src/components/bc-modal.ts
@@ -91,6 +91,9 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
             ? html`<bci-connecting class="flex w-full"></bci-connecting>`
             : html` <bc-router-outlet class="flex w-full"></bc-router-outlet>`}
         </div>
+        ${this._error
+          ? html`<p class="mt-4 text-red-500">${this._error}</p>`
+          : null}
       </div>
     </div>`;
   }
@@ -103,6 +106,7 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
       // Reset after close
       // TODO: is there a better way to reset state when the modal is closed?
       store.getState().setRoute('/start');
+      store.getState().setError(undefined);
       this.onClose?.();
     }, 200);
   };

--- a/src/components/bc-navbar.ts
+++ b/src/components/bc-navbar.ts
@@ -21,7 +21,7 @@ export class Navbar extends withTwind()(BitcoinConnectElement) {
       <div class="absolute left-0 h-full flex items-center justify-center">
         <div
           class="${classes.interactive} ${classes['text-neutral-secondary']}"
-          @click=${() => store.getState().setRoute(this.to)}
+          @click=${this._goBack}
         >
           ${backIcon}
         </div>
@@ -31,6 +31,11 @@ export class Navbar extends withTwind()(BitcoinConnectElement) {
       </div>
     </div>`;
   }
+
+  private _goBack = () => {
+    store.getState().setRoute(this.to);
+    store.getState().setError(undefined);
+  };
 }
 
 declare global {

--- a/src/components/bc-router-outlet.ts
+++ b/src/components/bc-router-outlet.ts
@@ -21,9 +21,7 @@ export class RouterOutlet extends withTwind()(BitcoinConnectElement) {
   }
 
   override render() {
-    return html`<div class="flex flex-col w-full pt-8">
-      ${routes[this._route]}
-    </div>`;
+    return html`<div class="flex flex-col w-full">${routes[this._route]}</div>`;
   }
 }
 

--- a/src/components/bc-start.ts
+++ b/src/components/bc-start.ts
@@ -36,7 +36,7 @@ export class Start extends withTwind()(BitcoinConnectElement) {
                 class="font-bold font-mono text-4xl align-bottom ${classes[
                   'text-brand-mixed'
                 ]}"
-                >${(this._balance || 0).toLocaleString('en', {
+                >${(this._balance || 0).toLocaleString(undefined, {
                   useGrouping: true,
                 })}</span
               >&nbsp;sats

--- a/src/components/bc-start.ts
+++ b/src/components/bc-start.ts
@@ -6,6 +6,7 @@ import {html} from 'lit';
 import {disconnectIcon} from './icons/disconnectIcon';
 import {hr} from './templates/hr';
 import './internal/bci-button';
+import './bc-connector-list';
 import {classes} from './css/classes';
 
 // TODO: split up this component into disconnected and connected
@@ -15,28 +16,7 @@ export class Start extends withTwind()(BitcoinConnectElement) {
     return html`<div
       class="flex flex-col justify-center items-center w-full font-sans"
     >
-      ${this._connecting
-        ? html`<div
-            class="${classes['text-foreground']} w-full flex-1 animate-pulse"
-          >
-            <h1
-              class="w-1/2 h-7 mx-auto bg-gray-200 dark:bg-gray-700 rounded-md"
-            ></h1>
-            <div
-              class="w-1/2 h-4 mt-8 mb-2 mx-auto bg-gray-200 dark:bg-gray-700 rounded-md"
-            ></div>
-            <div
-              class="mb-12 h-10 w-1/2 mx-auto bg-gray-200 dark:bg-gray-700 rounded-md"
-            ></div>
-            ${hr()}
-            <div
-              class="my-4 h-4 w-1/2 mx-auto bg-gray-200 dark:bg-gray-700 rounded-md"
-            ></div>
-            <div
-              class="h-10 w-1/2 mx-auto bg-gray-200 dark:bg-gray-700 rounded-md"
-            ></div>
-          </div>`
-        : this._connected
+      ${this._connected
         ? html` <h1 class="text-lg ${classes['text-neutral-secondary']}">
               Hello,
               <span class="font-bold ${classes['text-brand-mixed']}">

--- a/src/components/internal/bci-connecting.ts
+++ b/src/components/internal/bci-connecting.ts
@@ -1,0 +1,38 @@
+import {html} from 'lit';
+import {withTwind} from '../twind/withTwind';
+import {customElement} from 'lit/decorators.js';
+import {InternalElement} from './InternalElement';
+import {classes} from '../css/classes';
+import {hr} from '../templates/hr';
+
+@customElement('bci-connecting')
+export class Connecting extends withTwind()(InternalElement) {
+  override render() {
+    return html`<div
+      class="${classes['text-foreground']} w-full flex-1 animate-pulse"
+    >
+      <h1
+        class="w-1/2 h-7 mx-auto bg-gray-200 dark:bg-gray-700 rounded-md"
+      ></h1>
+      <div
+        class="w-1/2 h-4 mt-8 mb-2 mx-auto bg-gray-200 dark:bg-gray-700 rounded-md"
+      ></div>
+      <div
+        class="mb-12 h-10 w-1/2 mx-auto bg-gray-200 dark:bg-gray-700 rounded-md"
+      ></div>
+      ${hr()}
+      <div
+        class="my-4 h-4 w-1/2 mx-auto bg-gray-200 dark:bg-gray-700 rounded-md"
+      ></div>
+      <div
+        class="h-10 w-1/2 mx-auto bg-gray-200 dark:bg-gray-700 rounded-md"
+      ></div>
+    </div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bci-connecting': Connecting;
+  }
+}

--- a/src/components/pages/bc-lnbits.ts
+++ b/src/components/pages/bc-lnbits.ts
@@ -76,9 +76,6 @@ export class lnbitsPage extends withTwind()(BitcoinConnectElement) {
       return;
     }
 
-    // FIXME: do not change route - extract skeleton loader and add loading state in this component
-    // and make connect throw an error on failure
-    store.getState().setRoute('/start');
     await store.getState().connect({
       lnbitsAdminKey: this._lnbitsAdminKey,
       lnbitsInstanceUrl: this._lnbitsUrl,
@@ -86,7 +83,6 @@ export class lnbitsPage extends withTwind()(BitcoinConnectElement) {
       connectorType: 'lnbits',
     });
     if (!store.getState().connected) {
-      store.getState().setRoute('/lnbits');
       // TODO: show an error message directly on this page
       alert('Failed to connect. Please check your LNbits admin key and URL');
     }

--- a/src/components/pages/bc-lnbits.ts
+++ b/src/components/pages/bc-lnbits.ts
@@ -66,13 +66,11 @@ export class lnbitsPage extends withTwind()(BitcoinConnectElement) {
   }
   private async onConnect() {
     if (!this._lnbitsAdminKey) {
-      // TODO: show an error message directly on this page
-      alert('Please enter your admin key');
+      store.getState().setError('Please enter your admin key');
       return;
     }
     if (!this._lnbitsUrl) {
-      // TODO: show an error message directly on this page
-      alert('Please enter your LNbits instance URL');
+      store.getState().setError('Please enter your LNbits instance URL');
       return;
     }
 
@@ -82,10 +80,6 @@ export class lnbitsPage extends withTwind()(BitcoinConnectElement) {
       connectorName: lnbitsConnectorTitle,
       connectorType: 'lnbits',
     });
-    if (!store.getState().connected) {
-      // TODO: show an error message directly on this page
-      alert('Failed to connect. Please check your LNbits admin key and URL');
-    }
   }
 }
 

--- a/src/components/pages/bc-mutiny.ts
+++ b/src/components/pages/bc-mutiny.ts
@@ -61,8 +61,7 @@ export class MutinyPage extends withTwind()(BitcoinConnectElement) {
   }
   private async onConnect() {
     if (!this._nwcUrl) {
-      // TODO: show an error message directly on this page
-      alert('Please enter a URL');
+      store.getState().setError('Please enter a URL');
       return;
     }
 
@@ -71,10 +70,6 @@ export class MutinyPage extends withTwind()(BitcoinConnectElement) {
       connectorName: mutinyNWCConnectorTitle,
       connectorType: 'nwc.mutiny',
     });
-    if (!store.getState().connected) {
-      // TODO: show an error message directly on this page
-      alert('Failed to connect. Please check your NWC URL');
-    }
   }
 }
 

--- a/src/components/pages/bc-mutiny.ts
+++ b/src/components/pages/bc-mutiny.ts
@@ -66,16 +66,12 @@ export class MutinyPage extends withTwind()(BitcoinConnectElement) {
       return;
     }
 
-    // FIXME: do not change route - extract skeleton loader and add loading state in this component
-    // and make connect throw an error on failure
-    store.getState().setRoute('/start');
     await store.getState().connect({
       nwcUrl: this._nwcUrl,
       connectorName: mutinyNWCConnectorTitle,
       connectorType: 'nwc.mutiny',
     });
     if (!store.getState().connected) {
-      store.getState().setRoute('/mutiny');
       // TODO: show an error message directly on this page
       alert('Failed to connect. Please check your NWC URL');
     }

--- a/src/components/pages/bc-nwc.ts
+++ b/src/components/pages/bc-nwc.ts
@@ -50,8 +50,7 @@ export class NWCPage extends withTwind()(BitcoinConnectElement) {
   }
   private async onConnect() {
     if (!this._nwcUrl) {
-      // TODO: show an error message directly on this page
-      alert('Please enter a URL');
+      store.getState().setError('Please enter a URL');
       return;
     }
 
@@ -60,10 +59,6 @@ export class NWCPage extends withTwind()(BitcoinConnectElement) {
       connectorName: genericConnectorTitle,
       connectorType: 'nwc.generic',
     });
-    if (!store.getState().connected) {
-      // TODO: show an error message directly on this page
-      alert('Failed to connect. Please check your NWC URL');
-    }
   }
 }
 

--- a/src/components/pages/bc-nwc.ts
+++ b/src/components/pages/bc-nwc.ts
@@ -55,16 +55,12 @@ export class NWCPage extends withTwind()(BitcoinConnectElement) {
       return;
     }
 
-    // FIXME: do not change route - extract skeleton loader and add loading state in this component
-    // and make connect throw an error on failure
-    store.getState().setRoute('/start');
     await store.getState().connect({
       nwcUrl: this._nwcUrl,
       connectorName: genericConnectorTitle,
       connectorType: 'nwc.generic',
     });
     if (!store.getState().connected) {
-      store.getState().setRoute('/nwc');
       // TODO: show an error message directly on this page
       alert('Failed to connect. Please check your NWC URL');
     }

--- a/src/components/pages/bc-umbrel.ts
+++ b/src/components/pages/bc-umbrel.ts
@@ -41,10 +41,6 @@ export class UmbrelPage extends withTwind()(BitcoinConnectElement) {
       connectorName: 'Umbrel',
       connectorType: 'nwc.umbrel',
     });
-    if (!store.getState().connected) {
-      // TODO: show an error message directly on this page
-      alert('Failed to connect. Please check your NWC URL');
-    }
   }
 }
 

--- a/src/components/pages/bc-umbrel.ts
+++ b/src/components/pages/bc-umbrel.ts
@@ -36,17 +36,12 @@ export class UmbrelPage extends withTwind()(BitcoinConnectElement) {
       name: this._appName || 'Bitcoin Connect',
     });
 
-    // FIXME: do not change route - extract skeleton loader and add loading state in this component
-    // and make connect throw an error on failure
-    store.getState().setRoute('/start');
-
     await store.getState().connect({
       nwcUrl: nwc.getNostrWalletConnectUrl(),
       connectorName: 'Umbrel',
       connectorType: 'nwc.umbrel',
     });
     if (!store.getState().connected) {
-      store.getState().setRoute('/nwc');
       // TODO: show an error message directly on this page
       alert('Failed to connect. Please check your NWC URL');
     }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -91,6 +91,7 @@ const store = createStore<Store>((set, get) => ({
       balance: undefined,
       connectorName: undefined,
       fetchedConnectorInfo: false,
+      route: '/start',
     });
     deleteConfig();
     dispatchEvent('bc:disconnected');


### PR DESCRIPTION
partially fixes https://github.com/getAlby/bitcoin-connect/issues/83

https://github.com/getAlby/bitcoin-connect/pull/102 should be merged first.

Errors are now handled the same way across all connection pages (shown at the bottom of the modal, if there is one)

![image](https://github.com/getAlby/bitcoin-connect/assets/33993199/5a957c3e-0cfb-4628-b804-45d74b6251e1)
