### PR TITLE
fix: trigger onConnected callback on subscribe if already connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,14 +314,6 @@ import {disconnect} from '@getalby/bitcoin-connect';
 disconnect();
 ```
 
-#### Check connection status
-
-```ts
-import {isConnected} from '@getalby/bitcoin-connect';
-
-const isConnected = isConnected();
-```
-
 #### Events
 
 ##### onConnected

--- a/dev/vite/index.html
+++ b/dev/vite/index.html
@@ -245,8 +245,12 @@
       <button id="pay-invoice">Pay 1 sat to Alby team</button>
       <h3>Make an invoice</h3>
       <button id="make-invoice">Make a 1 sat invoice</button>
+      <h3>Try it yourself</h3>
+      <p>
+        Open devtools and use <b>window.bitcoinConnectSandbox</b> to access the
+        Bitcoin Connect API
+      </p>
     </div>
-    <script></script>
     <script type="module">
       import {LightningAddress} from 'https://cdn.skypack.dev/@getalby/lightning-tools';
       import {
@@ -383,6 +387,10 @@
         });
 
       document.addEventListener('bc:onpaid', (e) => console.log('PAID!', e));
+    </script>
+    <script type="module">
+      import * as bitcoinConnectSandbox from '../../src/index.ts';
+      window.bitcoinConnectSandbox = bitcoinConnectSandbox;
     </script>
   </body>
 </html>

--- a/src/api.ts
+++ b/src/api.ts
@@ -41,11 +41,16 @@ type LaunchPaymentModalArgs = {
 };
 
 /**
- * Listen to onConnected events which will fire when a user connects to a wallet
- * @param callback includes the webln provider that was connected
+ * Listen to onConnected events which will fire when a user connects to a wallet.
+ * If a provider is already available, the callback will be immediately fired.
+ * @param callback includes the webln provider that was (or is already) connected
  * @returns unsubscribe function
  */
 export function onConnected(callback: (provider: WebLNProvider) => void) {
+  if (store.getState().connected) {
+    callback(store.getState().provider!);
+  }
+
   const zustandUnsubscribe = store.subscribe(async (state, prevState) => {
     if (state.connected && !prevState.connected) {
       if (!state.provider) {
@@ -160,8 +165,12 @@ export async function requestProvider(): Promise<WebLNProvider> {
 
 /**
  * @returns true if user is connected to a wallet and WebLN is enabled
+ * @deprecated will be removed in v4.
  */
 export function isConnected() {
+  console.warn(
+    'Bitcoin Connect: isConnected is deprecated and will be removed in the next major version'
+  );
   return store.getState().connected;
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -41,7 +41,9 @@ type LaunchPaymentModalArgs = {
 };
 
 /**
- * Listen to onConnected events which will fire when a user connects to a wallet.
+ * Listen to onConnected events which will fire when a wallet is connected (either
+ * the user connects to a new wallet or when Bitcoin Connect boots and connects to a previously-connected wallet).
+ *
  * If a provider is already available, the callback will be immediately fired.
  * @param callback includes the webln provider that was (or is already) connected
  * @returns unsubscribe function

--- a/src/api.ts
+++ b/src/api.ts
@@ -41,10 +41,10 @@ type LaunchPaymentModalArgs = {
 };
 
 /**
- * Listen to onConnected events which will fire when a wallet is connected (either
+ * Subscribe to onConnected events which will fire when a wallet is connected (either
  * the user connects to a new wallet or when Bitcoin Connect boots and connects to a previously-connected wallet).
  *
- * If a provider is already available, the callback will be immediately fired.
+ * If a provider is already available when the subscription is created, the callback will be immediately fired.
  * @param callback includes the webln provider that was (or is already) connected
  * @returns unsubscribe function
  */
@@ -67,11 +67,17 @@ export function onConnected(callback: (provider: WebLNProvider) => void) {
 }
 
 /**
- * Listen to onConnecting events which will fire when a user is connecting to their wallet
+ * Subscribe to onConnecting events which will fire when a user is connecting to their wallet
+ *
+ * If a provider is already being connected to when the subscription is created, the callback will be immediately fired.
  * @param callback
  * @returns unsubscribe function
  */
 export function onConnecting(callback: () => void) {
+  if (store.getState().connecting) {
+    callback();
+  }
+
   const zustandUnsubscribe = store.subscribe(async (state, prevState) => {
     if (state.connecting && !prevState.connecting) {
       callback();


### PR DESCRIPTION
Fixes https://github.com/getAlby/bitcoin-connect/issues/176

Also deprecates isConnected api function