### PR TITLE
Add Customization Options for Payment Methods in Payment Request Modal

### DIFF
--- a/dev/vite/index.html
+++ b/dev/vite/index.html
@@ -222,6 +222,21 @@
       <bc-send-payment
         id="send-payment"
         invoice="lnbc10n1pj4g7ugpp5h0lld9qzh06ngn8ur756rva0ntfdfg34h298337rljjyztxy8rfqhp50kncf9zk35xg4lxewt4974ry6mudygsztsz8qn3ar8pn3mtpe50scqzzsxqyz5vqsp5lwlnu7xjs7hj7vltx7rhzsjf60l5mwckuw93qngjrz7sdhdkw7gs9qyyssqzy543rxhkdtncjrmuzlz4lrh2eauldawa9np5yysh7dhqhv8kaahydurha2cfelr7t6wt33xse7fdykupnjv36na6x6crrhy53lyg6cqf2jhjj"
+        payment-methods="all"
+      ></bc-send-payment>
+
+      <h2>Request Payment Screen Internal (no QR) </h2>
+      <bc-send-payment
+        id="send-payment"
+        invoice="lnbc10n1pj4g7ugpp5h0lld9qzh06ngn8ur756rva0ntfdfg34h298337rljjyztxy8rfqhp50kncf9zk35xg4lxewt4974ry6mudygsztsz8qn3ar8pn3mtpe50scqzzsxqyz5vqsp5lwlnu7xjs7hj7vltx7rhzsjf60l5mwckuw93qngjrz7sdhdkw7gs9qyyssqzy543rxhkdtncjrmuzlz4lrh2eauldawa9np5yysh7dhqhv8kaahydurha2cfelr7t6wt33xse7fdykupnjv36na6x6crrhy53lyg6cqf2jhjj"
+        payment-methods="internal"
+      ></bc-send-payment>
+
+      <h2>Request Payment Screen External (no connect) </h2>
+      <bc-send-payment
+        id="send-payment"
+        invoice="lnbc10n1pj4g7ugpp5h0lld9qzh06ngn8ur756rva0ntfdfg34h298337rljjyztxy8rfqhp50kncf9zk35xg4lxewt4974ry6mudygsztsz8qn3ar8pn3mtpe50scqzzsxqyz5vqsp5lwlnu7xjs7hj7vltx7rhzsjf60l5mwckuw93qngjrz7sdhdkw7gs9qyyssqzy543rxhkdtncjrmuzlz4lrh2eauldawa9np5yysh7dhqhv8kaahydurha2cfelr7t6wt33xse7fdykupnjv36na6x6crrhy53lyg6cqf2jhjj"
+        payment-methods="external"
       ></bc-send-payment>
 
       <h2>Start screen</h2>

--- a/dev/vite/index.html
+++ b/dev/vite/index.html
@@ -225,14 +225,14 @@
         payment-methods="all"
       ></bc-send-payment>
 
-      <h2>Request Payment Screen Internal (no QR) </h2>
+      <h2>Request Payment Screen Internal (no QR)</h2>
       <bc-send-payment
         id="send-payment"
         invoice="lnbc10n1pj4g7ugpp5h0lld9qzh06ngn8ur756rva0ntfdfg34h298337rljjyztxy8rfqhp50kncf9zk35xg4lxewt4974ry6mudygsztsz8qn3ar8pn3mtpe50scqzzsxqyz5vqsp5lwlnu7xjs7hj7vltx7rhzsjf60l5mwckuw93qngjrz7sdhdkw7gs9qyyssqzy543rxhkdtncjrmuzlz4lrh2eauldawa9np5yysh7dhqhv8kaahydurha2cfelr7t6wt33xse7fdykupnjv36na6x6crrhy53lyg6cqf2jhjj"
         payment-methods="internal"
       ></bc-send-payment>
 
-      <h2>Request Payment Screen External (no connect) </h2>
+      <h2>Request Payment Screen External (no connect)</h2>
       <bc-send-payment
         id="send-payment"
         invoice="lnbc10n1pj4g7ugpp5h0lld9qzh06ngn8ur756rva0ntfdfg34h298337rljjyztxy8rfqhp50kncf9zk35xg4lxewt4974ry6mudygsztsz8qn3ar8pn3mtpe50scqzzsxqyz5vqsp5lwlnu7xjs7hj7vltx7rhzsjf60l5mwckuw93qngjrz7sdhdkw7gs9qyyssqzy543rxhkdtncjrmuzlz4lrh2eauldawa9np5yysh7dhqhv8kaahydurha2cfelr7t6wt33xse7fdykupnjv36na6x6crrhy53lyg6cqf2jhjj"

--- a/src/components/pages/bc-send-payment.ts
+++ b/src/components/pages/bc-send-payment.ts
@@ -44,6 +44,12 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
   })
   paid?: boolean;
 
+  @property({
+    type: String,
+    attribute: 'payment-methods',
+  })
+  paymentMethods: 'all' | 'internal' | "external" = 'all';
+
   protected override updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
 
@@ -109,17 +115,29 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
   }
 
   private renderConnectWalletMobile() {
-    let displayInvoiceBtn = null
+    let internalMethods = null
+    let externalMethods = null
     let qrSection = null
-    
-    if (this._showQR) {
-      qrSection = this.renderQR();
-    } else {
-      displayInvoiceBtn = html`
+
+
+    if (this.paymentMethods === 'all' || this.paymentMethods === 'internal') {
+      internalMethods = html`
+        <bci-button block @click=${this._onClickConnectWallet}>
+          <span class="-ml-0.5">${bcIcon}</span>Connect Wallet
+        </bci-button>
+      `
+    }
+
+    if (this.paymentMethods === 'all' || this.paymentMethods === 'external') {
+      externalMethods = html`
         <bci-button block @click=${this._copyAndDisplayInvoice}>
           ${qrIcon} Copy & Display Invoice
         </bci-button>
       `;
+
+      if (this._showQR) {
+        qrSection = this.renderQR();
+      }
     }
 
     return html`
@@ -129,28 +147,49 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
             ${walletIcon} Open in a Bitcoin Wallet
           </bci-button>
         </a>
-        <bci-button block @click=${this._onClickConnectWallet}>
-          <span class="-ml-0.5">${bcIcon}</span>Connect Wallet
-        </bci-button>
-        ${displayInvoiceBtn}
+        ${internalMethods}
+        ${externalMethods}
       </div>
       ${qrSection}
     `;
   }
 
   private renderConnectWalletDesktop() {
+    let internalMethods = null;
+    if (this.paymentMethods === 'all' || this.paymentMethods === 'internal') {
+      internalMethods = html`
+        <div class="mt-8">
+          <bci-button variant="primary" @click=${this._onClickConnectWallet}>
+            <span class="-ml-0.5">${bcIcon}</span>
+            Connect Wallet to Pay
+          </bci-button>
+        </div>
+      `;
+    }
+
+    let separator = null;
+    if (this.paymentMethods === 'all') {
+      separator = html`
+        <div class="w-full py-4">${hr('or')}</div>
+      `;
+    }
+
+    let externalMethods = null;
+    if (this.paymentMethods === 'all' || this.paymentMethods === 'external') {
+      externalMethods = html`
+        <div class="flex flex-col items-center ${this.paymentMethods === 'external' ? 'mt-8' : ''}">
+          <p class="font-medium ${classes['text-neutral-secondary']}">
+            Scan to Pay
+          </p>
+          ${this.renderQR()}
+        </div>
+      `;
+    }
+
     return html`
-      <div class="mt-8">
-        <bci-button variant="primary" @click=${this._onClickConnectWallet}>
-          <span class="-ml-0.5">${bcIcon}</span>
-          Connect Wallet to Pay
-        </bci-button>
-      </div>
-      <div class="w-full py-4">${hr('or')}</div>
-      <p class="font-medium ${classes['text-neutral-secondary']}">
-        Scan to Pay
-      </p>
-      ${this.renderQR()}
+      ${internalMethods}
+      ${separator}
+      ${externalMethods}
     `;
   }
 

--- a/src/components/pages/bc-send-payment.ts
+++ b/src/components/pages/bc-send-payment.ts
@@ -31,6 +31,9 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
   @state()
   _showQR = false;
 
+  @state()
+  _qr = null as QRCode | null;
+
   @property({
     type: String,
   })
@@ -51,29 +54,8 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
     }
   }
 
-  override render() {
-    if (!this.invoice) {
-      return null;
-    }
-
-    let decodedInvoice: Invoice;
-    try {
-      decodedInvoice = new Invoice({pr: this.invoice});
-    } catch (error) {
-      console.error(error);
-      store.getState().setError((error as Error).message);
-      return null;
-    }
-    const errorCorrectionLevel = 'L';
-    const qr = qrcode(0, errorCorrectionLevel);
-    qr.addData(this.invoice);
-    qr.make();
-
-    const isMobileView = window.innerWidth < 600;
-
-    return html` <div
-      class="flex flex-col justify-center items-center font-sans w-full"
-    >
+  private renderHeading(decodedInvoice: Invoice) {
+    return html`
       <h2 class="text-2xl mb-6 ${classes['text-neutral-secondary']}">
         <span
           class="font-bold font-mono text-4xl align-bottom ${classes[
@@ -84,91 +66,169 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
           })}</span
         >&nbsp;sats
       </h2>
-      ${this._connected || this.paid
-        ? this.paid
-          ? html`<div
-              class="flex flex-col justify-center items-center ${classes[
-                'text-brand-mixed'
-              ]}"
-            >
-              <p class="font-bold">Paid!</p>
-              ${successAnimation}
-            </div>`
-          : this._isPaying
-          ? html`<div class="flex flex-col justify-center items-center">
-              <p class="${classes['text-neutral-secondary']} mb-5">Paying...</p>
-              ${waitingIcon(`w-48 h-48 ${classes['text-brand-mixed']}`)}
-            </div>`
-          : html`<bci-button variant="primary" @click=${this._payInvoice}>
-                <span class="-ml-0.5">${bcIcon}</span>
-                Confirm Payment
-              </bci-button>
-              ${disconnectSection(this._connectorName)} `
-        : html`
-            <div class="flex justify-center items-center">
-              ${waitingIcon(`w-7 h-7 ${classes['text-brand-mixed']}`)}
-              <p class="${classes['text-neutral-secondary']}">
-                Waiting for payment
-              </p>
-            </div>
+    `;
+  }
 
-            ${!isMobileView
-              ? html`<div class="mt-8">
-                    <bci-button variant="primary" @click=${
-                      this._onClickConnectWallet
-                    }>
-                    <span class="-ml-0.5">${bcIcon}</span>
-                    Connect Wallet to Pay
-                  </bci-button>
-                  </div>
-                  <div class="w-full py-4">${hr('or')}</div>
+  private renderPaidState() {
+    return html`
+      <div class="flex flex-col justify-center items-center ${classes['text-brand-mixed']}">
+        <p class="font-bold">Paid!</p>
+        ${successAnimation}
+      </div>
+    `
+  }
 
-                  <p class="font-medium ${classes['text-neutral-secondary']}">
-                    Scan to Pay
-                  </p>
-              </div>`
-              : html`
-                  <div class="mt-8 w-full flex flex-col gap-4">
-                    <a href="lightning:${this.invoice}">
-                      <bci-button variant="primary" block>
-                        ${walletIcon} Open in a Bitcoin Wallet
-                      </bci-button>
-                    </a>
-                    <bci-button block @click=${this._onClickConnectWallet}>
-                      <span class="-ml-0.5">${bcIcon}</span>Connect Wallet
-                    </bci-button>
-                    ${this._showQR
-                      ? null
-                      : html`<bci-button
-                          block
-                          @click=${this._copyAndDisplayInvoice}
-                        >
-                          ${qrIcon}Copy & Display Invoice
-                        </bci-button>`}
-                  </div>
-                `}
-            ${!isMobileView || this._showQR
-              ? html`
-                <!-- add margin only on dark mode because on dark mode the qr has a white border -->
-                <a href="lightning:${this.invoice}" class="dark:mt-2">
-                  <img src=${qr.createDataURL(4)} class="rounded-lg"></img>
-                </a>
-                <a
-                  @click=${this._copyInvoice}
-                  class="
-                  flex gap-1
-                  mt-4
-                  ${classes['text-brand-mixed']} ${
-                  classes.interactive
-                } font-semibold text-xs"
-                  >
-                  ${this._hasCopiedInvoice ? copiedIcon : copyIcon}
-                  ${this._hasCopiedInvoice ? 'Copied!' : 'Copy Invoice'}
-                </a>
-            `
-              : null}
-          `}
-    </div>`;
+  private renderPayingState() {
+    return html`
+      <div class="flex flex-col justify-center items-center">
+        <p class="${classes['text-neutral-secondary']} mb-5">Paying...</p>
+        ${waitingIcon(`w-48 h-48 ${classes['text-brand-mixed']}`)}
+      </div>
+    `;
+  }
+
+  private renderPaymentConfirmation() {
+    return html`
+      <bci-button variant="primary" @click=${this._payInvoice}>
+        <span class="-ml-0.5">${bcIcon}</span>
+        Confirm Payment
+      </bci-button>
+      ${disconnectSection(this._connectorName)}
+    `;
+  }
+
+  private renderWaitingForPayment() {
+    return html`
+      <div class="flex justify-center items-center">
+        ${waitingIcon(`w-7 h-7 ${classes['text-brand-mixed']}`)}
+        <p class="${classes['text-neutral-secondary']}">
+          Waiting for payment
+        </p>
+      </div>
+    `;
+  }
+
+  private renderConnectWalletMobile() {
+    let displayInvoiceBtn = null
+    let qrSection = null
+    
+    if (this._showQR) {
+      qrSection = this.renderQR();
+    } else {
+      displayInvoiceBtn = html`
+        <bci-button block @click=${this._copyAndDisplayInvoice}>
+          ${qrIcon} Copy & Display Invoice
+        </bci-button>
+      `;
+    }
+
+    return html`
+      <div class="mt-8 w-full flex flex-col gap-4">
+        <a href="lightning:${this.invoice}">
+          <bci-button variant="primary" block>
+            ${walletIcon} Open in a Bitcoin Wallet
+          </bci-button>
+        </a>
+        <bci-button block @click=${this._onClickConnectWallet}>
+          <span class="-ml-0.5">${bcIcon}</span>Connect Wallet
+        </bci-button>
+        ${displayInvoiceBtn}
+      </div>
+      ${qrSection}
+    `;
+  }
+
+  private renderConnectWalletDesktop() {
+    return html`
+      <div class="mt-8">
+        <bci-button variant="primary" @click=${this._onClickConnectWallet}>
+          <span class="-ml-0.5">${bcIcon}</span>
+          Connect Wallet to Pay
+        </bci-button>
+      </div>
+      <div class="w-full py-4">${hr('or')}</div>
+      <p class="font-medium ${classes['text-neutral-secondary']}">
+        Scan to Pay
+      </p>
+      ${this.renderQR()}
+    `;
+  }
+
+  private renderQR() {
+    if (!this._showQR || !this.invoice || !this._qr) {
+      return null;
+    }
+
+    return html`
+      <!-- add margin only on dark mode because on dark mode the qr has a white border -->
+      <a href="lightning:${this.invoice}" class="dark:mt-2">
+        <img src=${this._qr.createDataURL(4)} class="rounded-lg"></img>
+      </a>
+      <a
+        @click=${this._copyInvoice}
+        class="
+        flex gap-1
+        mt-4
+        ${classes['text-brand-mixed']} ${
+        classes.interactive
+      } font-semibold text-xs"
+        >
+        ${this._hasCopiedInvoice ? copiedIcon : copyIcon}
+        ${this._hasCopiedInvoice ? 'Copied!' : 'Copy Invoice'}
+      </a>
+    `;
+  }
+
+  override render() {
+    if (!this.invoice) {
+      return null;
+    }
+
+    const errorCorrectionLevel = 'L';
+    const qr = qrcode(0, errorCorrectionLevel);
+    qr.addData(this.invoice);
+    qr.make();
+
+    this._qr = qr;
+
+    let decodedInvoice: Invoice;
+    try {
+      decodedInvoice = new Invoice({pr: this.invoice});
+    } catch (error) {
+      console.error(error);
+      store.getState().setError((error as Error).message);
+      return null;
+    }
+
+    const isMobileView = window.innerWidth < 600;
+    if (!isMobileView) {
+      this._showQR = true;
+    }
+
+    let paymentStateElement;
+
+    if (this.paid) {
+      paymentStateElement = this.renderPaidState();
+    } else if (this._isPaying) {
+      paymentStateElement = this.renderPayingState();
+    } else if (this._connected) {
+      paymentStateElement = this.renderPaymentConfirmation();
+    } else {
+        paymentStateElement = html`
+          ${this.renderWaitingForPayment()}
+          ${isMobileView ?
+            this.renderConnectWalletMobile()
+            : this.renderConnectWalletDesktop()
+          }
+        `;
+    }
+
+    return html`
+      <div class="flex flex-col justify-center items-center font-sans w-full">
+        ${this.renderHeading(decodedInvoice)}
+        ${paymentStateElement}
+      </div>
+    `;
   }
 
   private _onClickConnectWallet() {

--- a/src/components/pages/bc-send-payment.ts
+++ b/src/components/pages/bc-send-payment.ts
@@ -48,7 +48,7 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
     type: String,
     attribute: 'payment-methods',
   })
-  paymentMethods: 'all' | 'internal' | "external" = 'all';
+  paymentMethods: 'all' | 'internal' | 'external' = 'all';
 
   protected override updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
@@ -77,11 +77,15 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
 
   private renderPaidState() {
     return html`
-      <div class="flex flex-col justify-center items-center ${classes['text-brand-mixed']}">
+      <div
+        class="flex flex-col justify-center items-center ${classes[
+          'text-brand-mixed'
+        ]}"
+      >
         <p class="font-bold">Paid!</p>
         ${successAnimation}
       </div>
-    `
+    `;
   }
 
   private renderPayingState() {
@@ -107,25 +111,22 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
     return html`
       <div class="flex justify-center items-center">
         ${waitingIcon(`w-7 h-7 ${classes['text-brand-mixed']}`)}
-        <p class="${classes['text-neutral-secondary']}">
-          Waiting for payment
-        </p>
+        <p class="${classes['text-neutral-secondary']}">Waiting for payment</p>
       </div>
     `;
   }
 
   private renderConnectWalletMobile() {
-    let internalMethods = null
-    let externalMethods = null
-    let qrSection = null
-
+    let internalMethods = null;
+    let externalMethods = null;
+    let qrSection = null;
 
     if (this.paymentMethods === 'all' || this.paymentMethods === 'internal') {
       internalMethods = html`
         <bci-button block @click=${this._onClickConnectWallet}>
           <span class="-ml-0.5">${bcIcon}</span>Connect Wallet
         </bci-button>
-      `
+      `;
     }
 
     if (this.paymentMethods === 'all' || this.paymentMethods === 'external') {
@@ -147,8 +148,7 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
             ${walletIcon} Open in a Bitcoin Wallet
           </bci-button>
         </a>
-        ${internalMethods}
-        ${externalMethods}
+        ${internalMethods} ${externalMethods}
       </div>
       ${qrSection}
     `;
@@ -169,15 +169,17 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
 
     let separator = null;
     if (this.paymentMethods === 'all') {
-      separator = html`
-        <div class="w-full py-4">${hr('or')}</div>
-      `;
+      separator = html` <div class="w-full py-4">${hr('or')}</div> `;
     }
 
     let externalMethods = null;
     if (this.paymentMethods === 'all' || this.paymentMethods === 'external') {
       externalMethods = html`
-        <div class="flex flex-col items-center ${this.paymentMethods === 'external' ? 'mt-8' : ''}">
+        <div
+          class="flex flex-col items-center ${this.paymentMethods === 'external'
+            ? 'mt-8'
+            : ''}"
+        >
           <p class="font-medium ${classes['text-neutral-secondary']}">
             Scan to Pay
           </p>
@@ -186,11 +188,7 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
       `;
     }
 
-    return html`
-      ${internalMethods}
-      ${separator}
-      ${externalMethods}
-    `;
+    return html` ${internalMethods} ${separator} ${externalMethods} `;
   }
 
   private renderQR() {
@@ -209,8 +207,8 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
         flex gap-1
         mt-4
         ${classes['text-brand-mixed']} ${
-        classes.interactive
-      } font-semibold text-xs"
+      classes.interactive
+    } font-semibold text-xs"
         >
         ${this._hasCopiedInvoice ? copiedIcon : copyIcon}
         ${this._hasCopiedInvoice ? 'Copied!' : 'Copy Invoice'}
@@ -253,19 +251,17 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
     } else if (this._connected) {
       paymentStateElement = this.renderPaymentConfirmation();
     } else {
-        paymentStateElement = html`
-          ${this.renderWaitingForPayment()}
-          ${isMobileView ?
-            this.renderConnectWalletMobile()
-            : this.renderConnectWalletDesktop()
-          }
-        `;
+      paymentStateElement = html`
+        ${this.renderWaitingForPayment()}
+        ${isMobileView
+          ? this.renderConnectWalletMobile()
+          : this.renderConnectWalletDesktop()}
+      `;
     }
 
     return html`
       <div class="flex flex-col justify-center items-center font-sans w-full">
-        ${this.renderHeading(decodedInvoice)}
-        ${paymentStateElement}
+        ${this.renderHeading(decodedInvoice)} ${paymentStateElement}
       </div>
     `;
   }


### PR DESCRIPTION
This pull request introduces a new feature that allows customization of the payment methods displayed in the payment request modal. 

The bc-send-payment component now accepts a `paymentMethods` property, which can be set to `all` (default), `internal`, or `external`

**internal**: Shows only the internal payment methods (connecting a wallet).
**external**: Displays only the external payment methods (QR code and invoice).
**all**: Displays both internal payment methods (connecting a wallet) and external payment methods (QR code and invoice).

The layout and spacing of the payment methods have been adjusted to ensure a consistent and visually appealing design, regardless of the selected payment options.

To use this feature, set the `payment-methods` property on the `bc-send-payment` component to the desired value:
```
<bc-send-payment paymentMethods="all|internal|external"></bc-send-payment>
```

The changes have been added to the `dev/vita` index, so you can see the results by running `yarn dev.`

Fix #212 