### PR TITLE
Feat: Optionally specify brand button text color rather than use luminance

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,15 +430,10 @@ These variables must be set at the root or on a container element wrapping any b
 ```css
 html {
   --bc-color-brand: #196ce7; /* Only 6-digit hex and rgb formats are supported! */
-}
-```
-
-Optional CSS variables for further customization:
-
-```css
-html {
   --bc-color-brand-dark: #3994ff; /* use a different brand color in dark mode */
   --bc-brand-mix: 100%; /* how much to mix the brand color with default foreground color */
+  --bc-color-brand-button-text: #ffffff; /* override text color for primary button. Normally this is based on the luminance of the brand color */
+  --bc-color-brand-button-text-dark: #ffffff; /* override text color for primary button in dark mode. Normally this is based on the luminance of the brand color in dark mode */
 }
 ```
 

--- a/src/components/css/classes.ts
+++ b/src/components/css/classes.ts
@@ -6,6 +6,8 @@ export const classes = {
   // text colors
   'text-brand': 'text-brand-light dark:text-brand-dark',
   'text-brand-mixed': 'text-brand-mixed-light dark:text-brand-mixed-dark',
+  'text-brand-button-text':
+    'text-brand-button-text-light dark:text-brand-button-text-dark',
   'text-foreground': 'text-foreground-light dark:text-foreground-dark',
   'text-neutral-primary':
     'text-neutral-primary-light dark:text-neutral-primary-dark',

--- a/src/components/internal/InternalElement.ts
+++ b/src/components/internal/InternalElement.ts
@@ -43,10 +43,19 @@ export class InternalElement extends LitElement {
     if (!globalThis.window) {
       return 0;
     }
+    const isDarkMode =
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
     const brandColor =
       window
         .getComputedStyle(this as HTMLElement)
-        .getPropertyValue('--bc-color-brand') || '#196CE7';
+        .getPropertyValue(
+          isDarkMode ? '--bc-color-brand-dark' : '--bc-color-brand'
+        ) ||
+      window
+        .getComputedStyle(this as HTMLElement)
+        .getPropertyValue('--bc-color-brand') ||
+      '#196CE7';
     function calculateLuminance(color: string) {
       if (color.startsWith('#')) {
         color = color.slice(1); // Remove the '#' character

--- a/src/components/internal/bci-button.ts
+++ b/src/components/internal/bci-button.ts
@@ -25,14 +25,34 @@ export class Button extends withTwind()(InternalElement) {
   block = false;
 
   override render() {
-    const brandColorLuminance = this._getBrandColorLuminance();
+    const isDarkMode =
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    const hasBrandButtonTextColor =
+      window
+        .getComputedStyle(this as HTMLElement)
+        .getPropertyValue(
+          isDarkMode
+            ? '--bc-color-brand-button-text-dark'
+            : '--bc-color-brand-button-text'
+        ) ||
+      window
+        .getComputedStyle(this as HTMLElement)
+        .getPropertyValue('--bc-color-brand-button-text');
 
     return html`<button
       class="w-full relative h-10 px-4 font-sans font-semibold rounded-lg flex justify-center items-center
         ${this.ghost ? '' : 'shadow'} rounded-lg w-full ${classes.interactive}
         ${this.variant === 'primary' ? `${classes['bg-brand']}` : ''}
         ${this.variant === 'primary'
-        ? `${brandColorLuminance > 0.5 ? 'text-black' : 'text-white'}`
+        ? `${
+            hasBrandButtonTextColor
+              ? classes['text-brand-button-text']
+              : this._getBrandColorLuminance() > 0.5
+              ? 'text-black'
+              : 'text-white'
+          }`
         : this.variant === 'secondary'
         ? `${classes['text-brand-mixed']}`
         : `${classes['text-neutral-tertiary']}`}

--- a/src/components/twind/withTwind.ts
+++ b/src/components/twind/withTwind.ts
@@ -6,6 +6,9 @@ import {LitElement} from 'lit';
 const colors = {
   'brand-light': 'var(--bc-color-brand, #196CE7)',
   'brand-dark': 'var(--bc-color-brand-dark, var(--bc-color-brand, #3994FF))',
+  'brand-button-text-light': 'var(--bc-color-brand-button-text)',
+  'brand-button-text-dark':
+    'var(--bc-color-brand-button-text-dark, var(--bc-color-brand-button-text))',
   'brand-mixed-light':
     'color-mix(in srgb, var(--bc-color-brand, #196CE7) var(--bc-brand-mix, 100%), black)',
   'brand-mixed-dark':


### PR DESCRIPTION
Based on https://github.com/getAlby/bitcoin-connect/pull/218 except without reliance on luminance