### PR TITLE
Add success animation after successfully connecting

### DIFF
--- a/src/components/bc-button.ts
+++ b/src/components/bc-button.ts
@@ -7,7 +7,7 @@ import {innerBorder} from './templates/innerBorder.js';
 import {classes} from './css/classes.js';
 import {launchModal} from '../api.js';
 import './bc-balance';
-import store from '../state/store.js';
+import store, {Store} from '../state/store.js';
 import {waitingIcon} from './icons/waitingIcon.js';
 
 /**
@@ -23,20 +23,24 @@ export class Button extends withTwind()(BitcoinConnectElement) {
 
   constructor() {
     super();
-
-    this._showBalance =
-      store.getState().bitcoinConnectConfig.showBalance &&
-      store.getState().supports('getBalance');
+    this.updateShowBalance(store.getState());
 
     // TODO: handle unsubscribe
-    store.subscribe((store) => {
-      this._showBalance =
-        store.bitcoinConnectConfig.showBalance && store.supports('getBalance');
+    store.subscribe((state) => {
+      this.updateShowBalance(state);
     });
+  }
+
+  private updateShowBalance(state: Store) {
+    this._showBalance =
+      state.bitcoinConnectConfig.showBalance &&
+      state.supports('getBalance') &&
+      state.connected;
   }
 
   override render() {
     const isLoading = this._connecting || (!this._connected && this._modalOpen);
+    const state = store.getState();
 
     return html`<div>
       <div
@@ -65,7 +69,7 @@ export class Button extends withTwind()(BitcoinConnectElement) {
               : html`${this.title}`}
           </span>
         </bci-button>
-        ${this._connected && this._showBalance
+        ${this._connected && this._showBalance && !state.isFirstConnection
           ? html`<bc-balance class="select-none cursor-pointer"></bc-balance> `
           : null}
       </div>

--- a/src/components/bc-start.ts
+++ b/src/components/bc-start.ts
@@ -44,18 +44,8 @@ export class Start extends withTwind()(BitcoinConnectElement) {
     >
       ${this._connected
         ? html`
-            ${this._showBalance
-              ? html`<span
-                    class="text-xs font-medium mb-2 ${classes[
-                      'text-neutral-secondary'
-                    ]}"
-                    >Balance</span
-                  >
-                  <bc-currency-switcher>
-                    <bc-balance class="text-2xl"></bc-balance>
-                  </bc-currency-switcher>`
-              : html`
-                  <div
+            ${store.getState().isFirstConnection
+              ? html` <div
                     class="flex flex-col items-center ${classes[
                       'text-brand-mixed'
                     ]}"
@@ -66,11 +56,24 @@ export class Start extends withTwind()(BitcoinConnectElement) {
                     ${successAnimation}
                   </div>
                   ${this._closeModalAfterAnimation()}
+                  ${this._showBalanceAfterDelay()}`
+              : html`
+                  ${this._showBalance
+                    ? html` <span
+                          class="text-xs font-medium mb-2 ${classes[
+                            'text-neutral-secondary'
+                          ]}"
+                        >
+                          Balance
+                        </span>
+                        <bc-currency-switcher>
+                          <bc-balance class="text-2xl"></bc-balance>
+                        </bc-currency-switcher>`
+                    : null}
                 `}
             ${disconnectSection(this._connectorName)}
           `
-        : html`
-            <h1
+        : html` <h1
               class="my-8 ${classes[
                 'text-neutral-primary'
               ]} w-64 max-w-full text-center"
@@ -92,9 +95,15 @@ export class Start extends withTwind()(BitcoinConnectElement) {
                   >Get one here</a
                 >
               </h1>
-            </div>
-          `}
+            </div>`}
     </div>`;
+  }
+
+  private _showBalanceAfterDelay() {
+    setTimeout(() => {
+      this._showBalance = true;
+    }, 2000);
+    return null;
   }
 }
 

--- a/src/components/bc-start.ts
+++ b/src/components/bc-start.ts
@@ -10,6 +10,7 @@ import './bc-balance';
 import store from '../state/store';
 import './bc-currency-switcher';
 import {successAnimation} from './images/success';
+import {closeModal} from '../api';
 
 // TODO: split up this component into disconnected and connected
 @customElement('bc-start')
@@ -31,6 +32,12 @@ export class Start extends withTwind()(BitcoinConnectElement) {
     });
   }
 
+  private _closeModalAfterAnimation() {
+    setTimeout(() => {
+      closeModal();
+    }, 3500);
+  }
+
   override render() {
     return html`<div
       class="flex flex-col justify-center items-center w-full font-sans"
@@ -49,7 +56,7 @@ export class Start extends withTwind()(BitcoinConnectElement) {
                   </bc-currency-switcher>`
               : html`
                   <div
-                    class="flex flex-col justify-center items-center ${classes[
+                    class="flex flex-col items-center ${classes[
                       'text-brand-mixed'
                     ]}"
                   >
@@ -58,6 +65,7 @@ export class Start extends withTwind()(BitcoinConnectElement) {
                     >
                     ${successAnimation}
                   </div>
+                  ${this._closeModalAfterAnimation()}
                 `}
             ${disconnectSection(this._connectorName)}
           `

--- a/src/components/bc-start.ts
+++ b/src/components/bc-start.ts
@@ -9,6 +9,7 @@ import {disconnectSection} from './templates/disconnectSection';
 import './bc-balance';
 import store from '../state/store';
 import './bc-currency-switcher';
+import {successAnimation} from './images/success';
 
 // TODO: split up this component into disconnected and connected
 @customElement('bc-start')
@@ -46,12 +47,18 @@ export class Start extends withTwind()(BitcoinConnectElement) {
                   <bc-currency-switcher>
                     <bc-balance class="text-2xl"></bc-balance>
                   </bc-currency-switcher>`
-              : html` <span
-                  class="text-lg font-medium mt-4 -mb-4 ${classes[
-                    'text-neutral-secondary'
-                  ]}"
-                  >Wallet Connected</span
-                >`}
+              : html`
+                  <div
+                    class="flex flex-col justify-center items-center ${classes[
+                      'text-brand-mixed'
+                    ]}"
+                  >
+                    <span class="text-lg font-bold mt-4 -mb-4"
+                      >Wallet Connected</span
+                    >
+                    ${successAnimation}
+                  </div>
+                `}
             ${disconnectSection(this._connectorName)}
           `
         : html`

--- a/src/components/bc-start.ts
+++ b/src/components/bc-start.ts
@@ -7,7 +7,7 @@ import './bc-connector-list';
 import {classes} from './css/classes';
 import {disconnectSection} from './templates/disconnectSection';
 import './bc-balance';
-import store from '../state/store';
+import store, {Store} from '../state/store';
 import './bc-currency-switcher';
 import {successAnimation} from './images/success';
 import {closeModal} from '../api';
@@ -20,22 +20,26 @@ export class Start extends withTwind()(BitcoinConnectElement) {
 
   constructor() {
     super();
-
-    this._showBalance =
-      store.getState().bitcoinConnectConfig.showBalance &&
-      store.getState().supports('getBalance');
+    this.updateShowBalance(store.getState());
 
     // TODO: handle unsubscribe
-    store.subscribe((store) => {
-      this._showBalance =
-        store.bitcoinConnectConfig.showBalance && store.supports('getBalance');
+    store.subscribe((state) => {
+      this.updateShowBalance(state);
     });
   }
 
+  private updateShowBalance(state: Store) {
+    this._showBalance =
+      state.bitcoinConnectConfig.showBalance && state.supports('getBalance');
+  }
+
   private _closeModalAfterAnimation() {
-    setTimeout(() => {
-      closeModal();
-    }, 3500);
+    // Only auto-close if it's the first connection
+    if (store.getState().isFirstConnection) {
+      setTimeout(() => {
+        closeModal();
+      }, 3500);
+    }
   }
 
   override render() {


### PR DESCRIPTION
Hello @rolznz,

This PR addresses Issue #100 by adding:

- Success animation: Added success animation after a wallet connected successfully.
- Modal closes after animation: After the success animation, modal closes automatically.
- Bitcoin connect button instant balance update: After the modal is closed, the bitcoin button gets the balance immediately and shows the modal with the balance when clicked on it.

Let me know if you'd need further adjustments! :-)
