### PR TITLE
#292 Added white borders to the rendered QR

### DIFF
--- a/src/components/pages/bc-send-payment.ts
+++ b/src/components/pages/bc-send-payment.ts
@@ -219,9 +219,18 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
       qr.addData(invoice);
       qr.make();
       const moduleCount = qr.getModuleCount();
-      canvas.width = moduleCount * 4;
-      canvas.height = moduleCount * 4;
-      qr.renderTo2dContext(ctx, 4);
+      const padding = 4; // Adding padding for white borders
+      const scale = 4;
+      canvas.width = moduleCount * scale + padding * 2;
+      canvas.height = moduleCount * scale + padding * 2;
+
+      // Fill the entire canvas with white first
+      ctx.fillStyle = 'white';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      // Move the context to account for padding before rendering QR
+      ctx.translate(padding, padding);
+      qr.renderTo2dContext(ctx, scale);
     }, 100);
 
     return html`

--- a/src/components/pages/bc-send-payment.ts
+++ b/src/components/pages/bc-send-payment.ts
@@ -219,24 +219,19 @@ export class SendPayment extends withTwind()(BitcoinConnectElement) {
       qr.addData(invoice);
       qr.make();
       const moduleCount = qr.getModuleCount();
-      const padding = 4; // Adding padding for white borders
       const scale = 4;
-      canvas.width = moduleCount * scale + padding * 2;
-      canvas.height = moduleCount * scale + padding * 2;
+      canvas.width = moduleCount * scale;
+      canvas.height = moduleCount * scale;
 
-      // Fill the entire canvas with white first
-      ctx.fillStyle = 'white';
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-      // Move the context to account for padding before rendering QR
-      ctx.translate(padding, padding);
       qr.renderTo2dContext(ctx, scale);
     }, 100);
 
     return html`
       <!-- add margin only on dark mode because on dark mode the qr has a white border -->
       <a href="lightning:${this.invoice}" class="dark:mt-2">
-        <canvas id="qr"></canvas>
+        <div class="bg-white p-1 inline-block">
+          <canvas id="qr"></canvas>
+        </div>
       </a>
       <a
         @click=${this._copyInvoice}


### PR DESCRIPTION
In this pull request, I have added white borders of 4px around the qr code which is making the qr code easy to scan. I have tested it using my phone (Samsung Fold 4) and its getting scanned perfectly fine.
<img width="473" alt="Screenshot 2025-04-25 at 7 39 43 PM" src="https://github.com/user-attachments/assets/031030cc-93d3-48fb-bb93-5fef17bdde17" />
