### PR TITLE
update Flash Wallet preferred relay url

### DIFF
--- a/src/components/pages/bc-flash-wallet.ts
+++ b/src/components/pages/bc-flash-wallet.ts
@@ -142,7 +142,7 @@ ${classes['text-brand-mixed']} ${classes.interactive} font-semibold text-xs"
       const nwaClient = new nwa.NWAClient({
         name: this._appName,
         icon: this._appIcon,
-        relayUrl: 'wss://relay.paywithflash.com',
+        relayUrl: 'wss://nwclay.paywithflash.com',
         requestMethods,
         notificationTypes: authorizationUrlOptions?.notificationTypes,
         maxAmount: authorizationUrlOptions?.maxAmount,


### PR DESCRIPTION
The Flash Wallet's relay `wss://relay.paywithflash.com` was causing problems for NWC events and so a new relay, `wss://nwclay.paywithflash.com`,  optimized for NWC was deployed and is best to use with the Flash Wallet.