### PR TITLE
fix: added border to give shadow effect in dark mode

### DIFF
--- a/src/components/connectors/ConnectorElement.ts
+++ b/src/components/connectors/ConnectorElement.ts
@@ -34,7 +34,7 @@ export abstract class ConnectorElement extends withTwind()(
       @click=${this._onClick}
     >
       <div
-        class="w-16 h-16 drop-shadow rounded-2xl flex justify-center items-center overflow-hidden"
+        class="w-16 h-16 drop-shadow-lg rounded-2xl flex justify-center items-center overflow-hidden border border-white/20"
         style="background: ${this._background};"
       >
         ${this._icon}

--- a/src/components/connectors/ConnectorElement.ts
+++ b/src/components/connectors/ConnectorElement.ts
@@ -34,7 +34,7 @@ export abstract class ConnectorElement extends withTwind()(
       @click=${this._onClick}
     >
       <div
-        class="w-16 h-16 drop-shadow-lg rounded-2xl flex justify-center items-center overflow-hidden border border-white/20"
+        class="w-16 h-16 drop-shadow-[0_10px_15px_rgba(0,0,0,0.25)] dark:drop-shadow-[0_10px_15px_rgba(255,255,255,0.15)] rounded-2xl flex justify-center items-center overflow-hidden"
         style="background: ${this._background};"
       >
         ${this._icon}


### PR DESCRIPTION
Adding a border could fix this , since dropshadow is already enabled on all the components


<img width="590" height="431" alt="Screenshot 2025-09-25 at 9 22 24 AM" src="https://github.com/user-attachments/assets/4168f721-0201-44a5-9e89-061ef029ab94" />
