### PR TITLE
fix: improve LNbits URL parsing with validation

### DIFF
--- a/src/components/pages/bc-lnbits.ts
+++ b/src/components/pages/bc-lnbits.ts
@@ -63,7 +63,7 @@ export class lnbitsPage extends withTwind()(BitcoinConnectElement) {
     this._lnbitsAdminKey = event.target.value;
   }
   private _lnbitsUrlChanged(event: {target: HTMLInputElement}) {
-    this._lnbitsUrl = event.target.value;
+    this._lnbitsUrl = event.target.value.trim();
   }
   private async onConnect() {
     if (!this._lnbitsAdminKey) {
@@ -75,12 +75,13 @@ export class lnbitsPage extends withTwind()(BitcoinConnectElement) {
       return;
     }
 
-    let lnbitsInstanceUrl = this._lnbitsUrl;
-    if (lnbitsInstanceUrl.endsWith('/')) {
-      lnbitsInstanceUrl = lnbitsInstanceUrl.substring(
-        0,
-        lnbitsInstanceUrl.length - 1
-      );
+    let lnbitsInstanceUrl: string;
+    try {
+      const url = new URL(this._lnbitsUrl);
+      lnbitsInstanceUrl = url.href.replace(/\/+$/, '');
+    } catch {
+      store.getState().setError('Please enter a valid URL');
+      return;
     }
 
     await store.getState().connect({

--- a/src/connectors/LnbitsConnector.ts
+++ b/src/connectors/LnbitsConnector.ts
@@ -149,7 +149,6 @@ export class LnbitsWebLNProvider implements WebLNProvider {
     args?: Record<string, unknown>
   ) {
     let body = null;
-    const query = '';
     const headers = new Headers();
     headers.append('Accept', 'application/json');
     headers.append('Content-Type', 'application/json');
@@ -159,9 +158,8 @@ export class LnbitsWebLNProvider implements WebLNProvider {
       body = JSON.stringify(args);
     } else if (args !== undefined) {
       throw new Error('TODO: support args in GET');
-      // query = ...
     }
-    const res = await fetch(this._instanceUrl + path + query, {
+    const res = await fetch(this._instanceUrl + path, {
       method,
       headers,
       body,


### PR DESCRIPTION
## Summary
- Use the URL API to validate LNbits instance URLs, catching malformed input with a user-friendly error
- Preserve the full URL path for reverse-proxied LNbits instances (e.g. `https://myserver.com/lnbits`)
- Trim whitespace from URL input
- Remove dead `query` variable in `requestLnbits`

## What changed

**bc-lnbits.ts**: Replaced manual trailing-slash strip with `new URL()` validation. Uses `url.href` (not `url.origin`) so base paths like `/lnbits` are preserved. Shows "Please enter a valid URL" on parse failure.

**LnbitsConnector.ts**: Removed unused `query` variable and dead comment. String concatenation `this._instanceUrl + path` preserved (it already handles base paths correctly).

## Test plan
- [x] `npm run build` passes
- [x] No new lint warnings (existing eslint config issue is pre-existing)
- [ ] Manual: enter `https://legend.lnbits.com` → connects as before
- [ ] Manual: enter `https://myserver.com/lnbits/` → trailing slash stripped, path preserved
- [ ] Manual: enter `not-a-url` → shows "Please enter a valid URL" error
- [ ] Manual: enter ` https://legend.lnbits.com ` (with spaces) → spaces trimmed, connects

Closes #244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LNbits URL validation with clearer errors for malformed addresses.
  * Automatically trims leading/trailing whitespace from LNbits URL inputs.
  * Normalizes LNbits instance URLs (e.g., removes stray trailing slashes) before connecting.
  * More reliable connector behavior when contacting LNbits, reducing connection failures and handling invalid URLs gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->