### PR TITLE
fix: don't show 'connected to' on connection error

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -86,7 +86,8 @@ const store = createStore<Store>((set, get) => ({
       try {
         info = await provider.getInfo();
       } catch (error) {
-        console.error('Failed to request wallet info');
+        console.error('Failed to request wallet info', error);
+        throw error;
       }
 
       // In case user cancels the connection


### PR DESCRIPTION
## Summary

Fixes #174 — When a wallet connection fails (e.g., invalid LNbits credentials), the UI incorrectly shows "Connected through [name]" and the Disconnect button.

## Root Cause

In `store.ts`, the `getInfo()` call's error is silently swallowed (lines 86-90). For connectors like LNbits, `getInfo()` makes a real API call to `/api/v1/wallet` which fails with bad credentials. Since the error is caught and ignored, execution continues to `set({ connected: true })`, causing the UI to display connection success.

The `bc-balance` component correctly shows the warning icon (because `getBalance()` also fails), but the rest of the UI still shows "connected."

## Fix

Re-throw the `getInfo()` error so it propagates to the outer `catch` block (line 114), which already:
1. Sets the error state for display
2. Sets `connecting: false`
3. Calls `disconnect()` to clear the connection state

This is the minimal correct fix — the error handling path already exists and works correctly; the inner catch was just preventing errors from reaching it.

## Testing

- With invalid LNbits credentials: connection now correctly shows error and does not display "Connected through" text
- With valid credentials: connection works normally (getInfo succeeds, no error thrown)
- Page reload reconnection: works normally since saved credentials are still valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during connection failures to properly display error states and disconnect, instead of leaving the app in an uncertain state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->