### PR TITLE
fix: fire webln:enabled event on successful connect (closes #82)

### DIFF
--- a/src/state/boot.ts
+++ b/src/state/boot.ts
@@ -16,7 +16,11 @@ function loadConfig() {
 
 function addEventListeners() {
   window.addEventListener('webln:enabled', () => {
-    if (!store.getState().connecting) {
+    // Skip if Bitcoin Connect itself dispatched the event (after a successful
+    // connect) or is already connecting. Otherwise we'd loop, or override
+    // the active connector with the extension one.
+    const {connecting, connected} = store.getState();
+    if (!connecting && !connected) {
       // webln was enabled from outside
       // TODO: use the same name and logic for figuring out what extension as the extension connector
       store.getState().connect(

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -106,6 +106,12 @@ const store = createStore<Store>((set, get) => ({
         route: connectOptions.redirectTo,
       });
 
+      // Notify external listeners that a WebLN provider is now available.
+      // See https://www.webln.guide/building-lightning-apps/webln-events
+      if (globalThis.window) {
+        window.dispatchEvent(new Event('webln:enabled'));
+      }
+
       // Only save config if persistConnection is enabled (default: true)
       const {bitcoinConnectConfig} = get();
       if (bitcoinConnectConfig.persistConnection !== false) {


### PR DESCRIPTION
Closes #82.

### Problem
Bitcoin Connect listens to the `webln:enabled` event in `src/state/boot.ts` to detect external WebLN providers (e.g. the Alby browser extension), but it never dispatches the event itself when one of its own connectors finishes connecting. Downstream code that subscribes to the standard WebLN event, as documented at https://www.webln.guide/building-lightning-apps/webln-events, never gets notified that a provider is available after a Bitcoin Connect flow.

The maintainer confirmed this on the issue thread (rolznz, 2023-10-20): "We still need to make the change in Bitcoin Connect to actually fire this event."

### Fix
1. `src/state/store.ts` — after `set({connected: true, …})` in the connect flow, dispatch `new Event('webln:enabled')` on `window`. Guarded by `globalThis.window` so SSR users do not crash.
2. `src/state/boot.ts` — also gate the listener on `!connected`, not just `!connecting`. Without this guard, our self-dispatched event would bounce back into the listener and trigger a redundant `extension.generic` connect, overriding the active connector.

### Testing
- `npx tsc --noEmit` passes for the touched files. The only remaining TS error is a pre-existing one in `src/test/my-element_test.ts` (placeholder file, unrelated import).
- I did not add a unit test because there is no existing test infrastructure for `state/store` or `state/boot` (the only test file in `src/test/` is the lit-element placeholder). Happy to bootstrap one if you want.
- Manually verified by tracing the flow: connect succeeds → store sets `connected: true` → dispatch fires → listener checks `connected: true` → early-returns. No loop. External listeners receive the event.

### Deliberately out of scope
- Setting `window.webln = provider` automatically. Issue #215 already discusses that as an intentional choice. This PR just fires the event; downstream apps still set `window.webln` themselves if they want to.
- A symmetric `webln:disabled` dispatch on `disconnect`. Not requested in #82, can be a follow-up.

### Behavior change to flag
External code that was relying on `webln:enabled` *not* being fired by BC may need a small update. This is the spec-compliant behavior, so the change should be acceptable, but worth a maintainer call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection state management to prevent redundant connection attempts when already connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->