### PR TITLE
docs: clear window.webln on disconnect (closes #215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ onDisconnected(() => {
 });
 ```
 
-Without the `onDisconnected` cleanup, your app can still call `window.webln.sendPayment()` after the user clicks Disconnect (see [#215](https://github.com/getAlby/bitcoin-connect/issues/215) for the original report).
+Without the `onDisconnected` cleanup, your app can still call `window.webln.sendPayment()` after the user clicks Disconnect.
 
 _More methods coming soon. Is something missing that you'd need? let us know!_
 

--- a/README.md
+++ b/README.md
@@ -441,15 +441,20 @@ unsub();
 
 ### WebLN global object
 
-> WARNING: webln is no longer injected into the window object by default. If you need this, execute the following code:
+> WARNING: webln is no longer injected into the window object by default. If you need this, you must also clear it on disconnect. Bitcoin Connect does not own `window.webln` once you've assigned it, so a disconnected wallet remains reachable via the saved global until you remove it. Pair `onConnected` with `onDisconnected`:
 
 ```ts
-import {onConnected} from '@getalby/bitcoin-connect';
+import {onConnected, onDisconnected} from '@getalby/bitcoin-connect';
 
 onConnected((provider) => {
   window.webln = provider;
 });
+onDisconnected(() => {
+  delete window.webln;
+});
 ```
+
+Without the `onDisconnected` cleanup, your app can still call `window.webln.sendPayment()` after the user clicks Disconnect (see [#215](https://github.com/getAlby/bitcoin-connect/issues/215) for the original report).
 
 _More methods coming soon. Is something missing that you'd need? let us know!_
 


### PR DESCRIPTION
## Summary

Closes #215.

The README's "WebLN global object" section recommends a pattern where consumers manually assign the provider to `window.webln` via `onConnected`. Issue #215 (filed 2024-05-06 by @uxbarrera) points out that this leaves a stale provider on the window after the user clicks Disconnect — `bitcoin-connect` does not own `window.webln` once the consumer has assigned it, so the saved reference outlives the wallet connection and the app can still call `window.webln.sendPayment()` post-disconnect.

This PR extends the existing example to pair `onConnected` with `onDisconnected` (already exported and documented earlier in the same README) and `delete window.webln` on disconnect.

## Why docs-only

This is the simplest landing path. The library itself can't fix this without owning `window.webln`, which would conflict with consumer expectations and other extensions that may also assign there. The right fix is documentation that makes the cleanup contract explicit.

Cross-link to my prior PR #384 review-thread where I cited #215 as the reason BC deliberately does not assign `window.webln` itself.

## Test plan

- [x] Re-render README locally — formatting renders correctly on GitHub flavored markdown
- [x] Spot-check that `onDisconnected` is the canonical export name (it is, per `src/api.ts:81`)
- [x] No code paths affected (docs-only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the WebLN global object is no longer injected by default.
  * Added guidance to pair connection and disconnection handlers to remove the global object on disconnect, ensuring it cannot be called after a wallet disconnects and preventing unexpected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->