### PR TITLE
fix: trap focus in modal for keyboard users (fixes #391)

### DIFF
--- a/src/components/bc-modal.ts
+++ b/src/components/bc-modal.ts
@@ -49,6 +49,7 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
       <div
         role="dialog"
         aria-modal="true"
+        aria-label="Bitcoin Connect"
         class="relative transition-all p-4 pt-6 pb-8 rounded-2xl shadow-2xl flex flex-col w-full bg-white dark:bg-black max-w-md max-sm:rounded-b-none
         animate-fade-in max-sm:animate-slide-up max-h-[90vh] overflow-y-auto"
       >

--- a/src/components/bc-modal.ts
+++ b/src/components/bc-modal.ts
@@ -12,15 +12,26 @@ const FOCUSABLE_SELECTOR =
 @customElement('bc-modal')
 export class Modal extends withTwind()(BitcoinConnectElement) {
   private _previouslyFocused: Element | null = null;
+  private _inertedElements: Element[] = [];
 
   override connectedCallback() {
     super.connectedCallback();
     this._previouslyFocused = document.activeElement;
+    for (const child of document.body.children) {
+      if (child !== this) {
+        (child as HTMLElement).inert = true;
+        this._inertedElements.push(child);
+      }
+    }
     document.addEventListener('keydown', this._handleKeyDown);
   }
 
   override disconnectedCallback() {
     document.removeEventListener('keydown', this._handleKeyDown);
+    for (const child of this._inertedElements) {
+      (child as HTMLElement).inert = false;
+    }
+    this._inertedElements = [];
     if (this._previouslyFocused instanceof HTMLElement) {
       this._previouslyFocused.focus();
     }
@@ -46,20 +57,40 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
       <div
         role="dialog"
         aria-modal="true"
-        class="transition-all p-4 pt-6 pb-8 rounded-2xl shadow-2xl flex flex-col w-full bg-white dark:bg-black max-w-md max-sm:rounded-b-none
+        class="relative transition-all p-4 pt-6 pb-8 rounded-2xl shadow-2xl flex flex-col w-full bg-white dark:bg-black max-w-md max-sm:rounded-b-none
         animate-fade-in max-sm:animate-slide-up max-h-[90vh] overflow-y-auto"
       >
+        <div
+          tabindex="0"
+          aria-hidden="true"
+          class="absolute w-px h-px p-0 -m-px overflow-hidden border-0"
+          @focus=${this._focusLastContent}
+        ></div>
         <slot @onclose=${this._handleClose}></slot>
+        <div
+          tabindex="0"
+          aria-hidden="true"
+          class="absolute w-px h-px p-0 -m-px overflow-hidden border-0"
+          @focus=${this._focusFirstContent}
+        ></div>
       </div>
     </div>`;
+  }
+
+  private _isVisible(element: HTMLElement): boolean {
+    return element.getClientRects().length > 0;
   }
 
   private _getFocusableElements(): HTMLElement[] {
     const elements: HTMLElement[] = [];
 
     const walk = (node: Element) => {
-      if (node.matches(FOCUSABLE_SELECTOR)) {
-        elements.push(node as HTMLElement);
+      if (
+        node instanceof HTMLElement &&
+        node.matches(FOCUSABLE_SELECTOR) &&
+        this._isVisible(node)
+      ) {
+        elements.push(node);
       }
       if (node.shadowRoot) {
         for (const child of node.shadowRoot.children) {
@@ -75,11 +106,37 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
       walk(child);
     }
 
-    return elements;
+    const deduped = elements.filter(
+      (element, _, all) =>
+        !all.some(
+          (other) => other !== element && other.contains(element)
+        )
+    );
+
+    return deduped.sort((a, b) => {
+      const position = a.compareDocumentPosition(b);
+      if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+        return -1;
+      }
+      if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+        return 1;
+      }
+      return 0;
+    });
   }
 
   private _containsFocus(element: Element): boolean {
     return element === this || this.contains(element);
+  }
+
+  private _focusFirstContent() {
+    const focusable = this._getFocusableElements();
+    focusable[0]?.focus();
+  }
+
+  private _focusLastContent() {
+    const focusable = this._getFocusableElements();
+    focusable[focusable.length - 1]?.focus();
   }
 
   private _handleKeyDown = (event: KeyboardEvent) => {
@@ -87,28 +144,14 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
       return;
     }
 
-    const focusable = this._getFocusableElements();
-    if (focusable.length === 0) {
-      return;
-    }
-
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
     const active = document.activeElement;
-
-    if (!active || !this._containsFocus(active)) {
-      event.preventDefault();
-      (event.shiftKey ? last : first).focus();
+    if (!active || this._containsFocus(active)) {
       return;
     }
 
-    if (event.shiftKey && active === first) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && active === last) {
-      event.preventDefault();
-      first.focus();
-    }
+    event.preventDefault();
+    const focusable = this._getFocusableElements();
+    (event.shiftKey ? focusable[focusable.length - 1] : focusable[0])?.focus();
   };
 
   private _handleClose = () => {

--- a/src/components/bc-modal.ts
+++ b/src/components/bc-modal.ts
@@ -6,8 +6,35 @@ import {withTwind} from './twind/withTwind';
 import './bc-modal-header';
 import {closeModal} from '../api';
 
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 @customElement('bc-modal')
 export class Modal extends withTwind()(BitcoinConnectElement) {
+  private _previouslyFocused: Element | null = null;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this._previouslyFocused = document.activeElement;
+    document.addEventListener('keydown', this._handleKeyDown);
+  }
+
+  override disconnectedCallback() {
+    document.removeEventListener('keydown', this._handleKeyDown);
+    if (this._previouslyFocused instanceof HTMLElement) {
+      this._previouslyFocused.focus();
+    }
+    super.disconnectedCallback();
+  }
+
+  override async firstUpdated() {
+    await this.updateComplete;
+    requestAnimationFrame(() => {
+      const focusable = this._getFocusableElements();
+      focusable[0]?.focus();
+    });
+  }
+
   override render() {
     return html` <div
       class="fixed top-0 left-0 w-full h-full flex justify-center items-end sm:items-center z-[21000]"
@@ -17,6 +44,8 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
         @click=${this._handleClose}
       ></div>
       <div
+        role="dialog"
+        aria-modal="true"
         class="transition-all p-4 pt-6 pb-8 rounded-2xl shadow-2xl flex flex-col w-full bg-white dark:bg-black max-w-md max-sm:rounded-b-none
         animate-fade-in max-sm:animate-slide-up max-h-[90vh] overflow-y-auto"
       >
@@ -24,6 +53,63 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
       </div>
     </div>`;
   }
+
+  private _getFocusableElements(): HTMLElement[] {
+    const elements: HTMLElement[] = [];
+
+    const walk = (node: Element) => {
+      if (node.matches(FOCUSABLE_SELECTOR)) {
+        elements.push(node as HTMLElement);
+      }
+      if (node.shadowRoot) {
+        for (const child of node.shadowRoot.children) {
+          walk(child as Element);
+        }
+      }
+      for (const child of node.children) {
+        walk(child as Element);
+      }
+    };
+
+    for (const child of this.children) {
+      walk(child);
+    }
+
+    return elements;
+  }
+
+  private _containsFocus(element: Element): boolean {
+    return element === this || this.contains(element);
+  }
+
+  private _handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const focusable = this._getFocusableElements();
+    if (focusable.length === 0) {
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+
+    if (!active || !this._containsFocus(active)) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+      return;
+    }
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   private _handleClose = () => {
     closeModal();

--- a/src/components/bc-modal.ts
+++ b/src/components/bc-modal.ts
@@ -12,12 +12,6 @@ const FOCUSABLE =
 @customElement('bc-modal')
 export class Modal extends withTwind()(BitcoinConnectElement) {
   private _previouslyFocused: Element | null = null;
-
-  override connectedCallback() {
-    super.connectedCallback();
-    this._previouslyFocused = document.activeElement;
-export class Modal extends withTwind()(BitcoinConnectElement) {
-  private _previouslyFocused: Element | null = null;
   private _previousInertState = new Map<HTMLElement, boolean>();
 
   override connectedCallback() {
@@ -37,11 +31,6 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
       el.inert = wasInert;
     }
     this._previousInertState.clear();
-    if (this._previouslyFocused instanceof HTMLElement) {
-      this._previouslyFocused.focus();
-    }
-    super.disconnectedCallback();
-  }
     if (this._previouslyFocused instanceof HTMLElement) {
       this._previouslyFocused.focus();
     }

--- a/src/components/bc-modal.ts
+++ b/src/components/bc-modal.ts
@@ -6,13 +6,12 @@ import {withTwind} from './twind/withTwind';
 import './bc-modal-header';
 import {closeModal} from '../api';
 
-const FOCUSABLE_SELECTOR =
+const FOCUSABLE =
   'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 @customElement('bc-modal')
 export class Modal extends withTwind()(BitcoinConnectElement) {
   private _previouslyFocused: Element | null = null;
-  private _inertedElements: Element[] = [];
 
   override connectedCallback() {
     super.connectedCallback();
@@ -20,18 +19,14 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
     for (const child of document.body.children) {
       if (child !== this) {
         (child as HTMLElement).inert = true;
-        this._inertedElements.push(child);
       }
     }
-    document.addEventListener('keydown', this._handleKeyDown);
   }
 
   override disconnectedCallback() {
-    document.removeEventListener('keydown', this._handleKeyDown);
-    for (const child of this._inertedElements) {
+    for (const child of document.body.children) {
       (child as HTMLElement).inert = false;
     }
-    this._inertedElements = [];
     if (this._previouslyFocused instanceof HTMLElement) {
       this._previouslyFocused.focus();
     }
@@ -40,10 +35,7 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
 
   override async firstUpdated() {
     await this.updateComplete;
-    requestAnimationFrame(() => {
-      const focusable = this._getFocusableElements();
-      focusable[0]?.focus();
-    });
+    requestAnimationFrame(() => this._getFocusableElements()[0]?.focus());
   }
 
   override render() {
@@ -64,32 +56,24 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
           tabindex="0"
           aria-hidden="true"
           class="absolute w-px h-px p-0 -m-px overflow-hidden border-0"
-          @focus=${this._focusLastContent}
+          @focus=${this._focusLast}
         ></div>
         <slot @onclose=${this._handleClose}></slot>
         <div
           tabindex="0"
           aria-hidden="true"
           class="absolute w-px h-px p-0 -m-px overflow-hidden border-0"
-          @focus=${this._focusFirstContent}
+          @focus=${this._focusFirst}
         ></div>
       </div>
     </div>`;
-  }
-
-  private _isVisible(element: HTMLElement): boolean {
-    return element.getClientRects().length > 0;
   }
 
   private _getFocusableElements(): HTMLElement[] {
     const elements: HTMLElement[] = [];
 
     const walk = (node: Element) => {
-      if (
-        node instanceof HTMLElement &&
-        node.matches(FOCUSABLE_SELECTOR) &&
-        this._isVisible(node)
-      ) {
+      if (node instanceof HTMLElement && node.matches(FOCUSABLE)) {
         elements.push(node);
       }
       if (node.shadowRoot) {
@@ -106,52 +90,16 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
       walk(child);
     }
 
-    const deduped = elements.filter(
-      (element, _, all) =>
-        !all.some(
-          (other) => other !== element && other.contains(element)
-        )
-    );
-
-    return deduped.sort((a, b) => {
-      const position = a.compareDocumentPosition(b);
-      if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
-        return -1;
-      }
-      if (position & Node.DOCUMENT_POSITION_PRECEDING) {
-        return 1;
-      }
-      return 0;
-    });
+    return elements;
   }
 
-  private _containsFocus(element: Element): boolean {
-    return element === this || this.contains(element);
-  }
+  private _focusFirst = () => {
+    this._getFocusableElements()[0]?.focus();
+  };
 
-  private _focusFirstContent() {
-    const focusable = this._getFocusableElements();
-    focusable[0]?.focus();
-  }
-
-  private _focusLastContent() {
+  private _focusLast = () => {
     const focusable = this._getFocusableElements();
     focusable[focusable.length - 1]?.focus();
-  }
-
-  private _handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key !== 'Tab') {
-      return;
-    }
-
-    const active = document.activeElement;
-    if (!active || this._containsFocus(active)) {
-      return;
-    }
-
-    event.preventDefault();
-    const focusable = this._getFocusableElements();
-    (event.shiftKey ? focusable[focusable.length - 1] : focusable[0])?.focus();
   };
 
   private _handleClose = () => {

--- a/src/components/bc-modal.ts
+++ b/src/components/bc-modal.ts
@@ -16,17 +16,32 @@ export class Modal extends withTwind()(BitcoinConnectElement) {
   override connectedCallback() {
     super.connectedCallback();
     this._previouslyFocused = document.activeElement;
+export class Modal extends withTwind()(BitcoinConnectElement) {
+  private _previouslyFocused: Element | null = null;
+  private _previousInertState = new Map<HTMLElement, boolean>();
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this._previouslyFocused = document.activeElement;
     for (const child of document.body.children) {
       if (child !== this) {
-        (child as HTMLElement).inert = true;
+        const el = child as HTMLElement;
+        this._previousInertState.set(el, el.inert);
+        el.inert = true;
       }
     }
   }
 
   override disconnectedCallback() {
-    for (const child of document.body.children) {
-      (child as HTMLElement).inert = false;
+    for (const [el, wasInert] of this._previousInertState.entries()) {
+      el.inert = wasInert;
     }
+    this._previousInertState.clear();
+    if (this._previouslyFocused instanceof HTMLElement) {
+      this._previouslyFocused.focus();
+    }
+    super.disconnectedCallback();
+  }
     if (this._previouslyFocused instanceof HTMLElement) {
       this._previouslyFocused.focus();
     }

--- a/src/components/bc-modal.ts
+++ b/src/components/bc-modal.ts
@@ -12,25 +12,13 @@ const FOCUSABLE =
 @customElement('bc-modal')
 export class Modal extends withTwind()(BitcoinConnectElement) {
   private _previouslyFocused: Element | null = null;
-  private _previousInertState = new Map<HTMLElement, boolean>();
 
   override connectedCallback() {
     super.connectedCallback();
     this._previouslyFocused = document.activeElement;
-    for (const child of document.body.children) {
-      if (child !== this) {
-        const el = child as HTMLElement;
-        this._previousInertState.set(el, el.inert);
-        el.inert = true;
-      }
-    }
   }
 
   override disconnectedCallback() {
-    for (const [el, wasInert] of this._previousInertState.entries()) {
-      el.inert = wasInert;
-    }
-    this._previousInertState.clear();
     if (this._previouslyFocused instanceof HTMLElement) {
       this._previouslyFocused.focus();
     }


### PR DESCRIPTION
## Summary
- Add focus trap and initial focus to `bc-modal` so keyboard users can navigate the payment dialog without Tab escaping to the page behind it
- Restore focus to the previously focused element when the modal closes
- Add `role="dialog"` and `aria-modal="true"` on the modal panel

Fixes #391

## Root cause
The modal was a visual overlay only — it did not manage focus. Tab cycled through background page elements until the user clicked inside the modal. Once focus entered the modal, Enter on Confirm Payment worked as expected.

## Test plan
- [x] `yarn dev` → open payment modal without clicking inside it
- [x] Tab cycles through modal controls only (close, Connect Wallet, etc.)
- [x] Connect wallet → Tab to Confirm Payment → Enter confirms payment
- [x] Close modal → focus returns to the element that opened it


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal now remembers the element focused before opening and restores focus when closed.
  * Improved focus trapping within the modal using focus sentinels, plus automatic movement between the first and last focusable elements.
  * On open, the modal focuses the first focusable control available inside nested shadow roots.
* **Accessibility**
  * Added dialog semantics for screen readers (role, modal state, and labeling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->